### PR TITLE
[Build] Update dockerfile to use compatible version of Bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ addons:
 matrix:
   include:
   - env: ELASTIC_STACK_VERSION=5.6.12
-  - env: ELASTIC_STACK_VERSION=6.4.1
-  - env: ELASTIC_STACK_VERSION=7.0.0-alpha1-SNAPSHOT
+  - env: ELASTIC_STACK_VERSION=6.5.4
+  - env: ELASTIC_STACK_VERSION=7.0.0-alpha1
   fast_finish: true
 install: ci/unit/docker-setup.sh
 script: ci/unit/docker-run.sh

--- a/ci/unit/Dockerfile
+++ b/ci/unit/Dockerfile
@@ -5,6 +5,6 @@ RUN cp /usr/share/logstash/logstash-core/versions-gem-copy.yml /usr/share/logsta
 ENV PATH="${PATH}:/usr/share/logstash/vendor/jruby/bin"
 ENV LOGSTASH_SOURCE=1
 ENV JARS_SKIP="true"
-RUN gem install bundler
+RUN gem install bundler -v '< 2'
 WORKDIR /usr/share/plugins/this
 RUN bundle install


### PR DESCRIPTION
Bundler 2.0 introduced requirements that are incompatible with the version of Ruby shipped with Logstash 5.6. This commit installs a pre 2.0 version of Bundler.