### PR TITLE
Add elastic-app-search gem to the gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.1
+  - Added missed dependency (elastic-app-search) to the gemspec, fixes issue [#17](https://github.com/logstash-plugins/logstash-output-elastic_app_search/issues/17)
+
 ## 1.1.0
   - Switched AppSearch client library from Java to Ruby [#12](https://github.com/logstash-plugins/logstash-output-elastic_app_search/issues/12)
   - Covered with integration tests and dockerized local AppSearch server instance.

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ bundle exec rspec
 
 #### CI in local machine
 The plugins comes with a `.ci` folder that contains Docker configurations to run on the CI, however to run it locally
-you have to a local checkout of the [CI's infrastructure project](https://github.com/logstash-plugins/.ci/) and symlink 
-some files from that into the local clone's `.ci`. Supposing you have the CI project in <CI> the steps from local clone 
-ot the plugin, are:
+you have to checkout the [CI's infrastructure project](https://github.com/logstash-plugins/.ci/) and symlink 
+some files from that into the local clone's `.ci`. Supposing you have the CI project in <CI>, the steps from local clone 
+of the plugin are:
 - `cd .ci`
 - `ln -s <CI>/.ci/docker-setup.sh docker-setup.sh`
 - `ln -s <CI>/.ci/docker-run.sh docker-run.sh`

--- a/logstash-output-elastic_app_search.gemspec
+++ b/logstash-output-elastic_app_search.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-output-elastic_app_search'
-  s.version       = '1.1.0'
+  s.version       = '1.1.1'
   s.licenses      = ['Apache-2.0']
   s.summary       = 'Index data to Elastic App Search'
   s.description   = 'This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program'
@@ -17,10 +17,9 @@ Gem::Specification.new do |s|
   # Special flag to let us know this is actually a logstash plugin
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
-  s.add_development_dependency 'jar-dependencies', '~> 0.4'
-
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", "~> 2.0"
   s.add_runtime_dependency "logstash-codec-plain"
+  s.add_runtime_dependency "elastic-app-search", '~>7.8.0'
   s.add_development_dependency "logstash-devutils"
 end


### PR DESCRIPTION
When the plugin switched from Java client to Ruby client, the depencies in gemspec file wasn't updated.

Fixes #17